### PR TITLE
Change linewidth in gridlayer

### DIFF
--- a/src/GridLayer.js
+++ b/src/GridLayer.js
@@ -18,7 +18,8 @@ function GridLayer(layer) {
       gridMaterial = new THREE.LineBasicMaterial(
     {
       color: this.neonGreen,
-      linewidth: 2
+      linewidth: 1 /* will always be 1 on windows no matter what you
+                      actually set it to because of the ANGLE layer */
     }
   );
 


### PR DESCRIPTION
It has to be 1 for windows reasons.

Conflicts:
    src/GridLayer.js
