### PR TITLE
Remove global reference in Grid Layer

### DIFF
--- a/src/GridLayer.js
+++ b/src/GridLayer.js
@@ -25,7 +25,7 @@ function GridLayer(layer) {
   /* Create grid */
   /*             */
 
-  var gridGeometry = new THREE.Geometry();
+  var gridGeometry = new THREE.Geometry(),
       gridMaterial = new THREE.LineBasicMaterial(
     {
       color: this.neonGreen,


### PR DESCRIPTION
This is to prevent unintentional problems.
