### PR TITLE
Change non-human being part of max text

### DIFF
--- a/res/layers.json
+++ b/res/layers.json
@@ -371,7 +371,7 @@
       "title": "Max Headroom",
       "body": [
         "- dr. who interrupter",
-        "- non-human being",
+        "- wave catcher",
         "- witty"
       ],
       "offset": {


### PR DESCRIPTION
The text that said "non-human being" is correct for max himself, but we
use pictures of the hacker, who is human....or is he? So the text is
changed to wave catcher. This has two meanings: first he says "catch the
wave" in the signal highjacking, secondly he did highjack the signal by
sending higher frequency waves to the viewers than the tv signal.
