### PR TITLE
Remove Loader.start from all layers

### DIFF
--- a/src/AtomiumLayer.js
+++ b/src/AtomiumLayer.js
@@ -18,9 +18,6 @@ function AtomiumLayer(layer) {
   this.scene.add(this.bg);
   this.innerCubeGlow = 0;
   this.snareGlow = 0;
-  if(!window.FILES) {
-    Loader.start(function(){}, function(){});
-  }
 
   this.random = Random(1337);
 

--- a/src/BGLayer.js
+++ b/src/BGLayer.js
@@ -2,7 +2,6 @@ function BGLayer() {
   this.shaderPass = new THREE.ShaderPass(SHADERS.img);
   this.bg = Loader.loadTexture('res/bg.jpg');
   this.shaderPass.uniforms.img.value = this.bg;
-  Loader.start(function() {}, function() {});
 }
 
 BGLayer.prototype.update = function() {

--- a/src/GridLayer.js
+++ b/src/GridLayer.js
@@ -164,10 +164,6 @@ function GridLayer(layer) {
   this.pyramidWrapper.position.z = -this.viewDistance;
   this.scene.add(this.pyramidWrapper);
 
-  if (!window.FILES) {
-    Loader.start(function () {}, function() {});
-  }
-
   this.renderPass = new THREE.RenderPass(this.scene, this.camera);
 }
 

--- a/src/IntroLayer.js
+++ b/src/IntroLayer.js
@@ -121,7 +121,6 @@ function IntroLayer(layer) {
   pointLight.position.z = 130;
   this.scene.add(pointLight);
   this.renderPass = new THREE.RenderPass(this.scene, this.camera);
-  Loader.start(function(){}, function(){});
 }
 
 IntroLayer.prototype.getEffectComposerPass = function() {

--- a/src/MaxLayer.js
+++ b/src/MaxLayer.js
@@ -109,9 +109,6 @@ function MaxLayer(layer) {
   pointLight.position.z = 1300;
   this.scene.add(pointLight);
 
-  if(!window.FILES) {
-    Loader.start(function(){}, function(){});
-  }
   this.renderPass = new THREE.RenderPass(this.scene, this.camera);
 }
 

--- a/src/OutroLayer.js
+++ b/src/OutroLayer.js
@@ -15,10 +15,6 @@ function OutroLayer(layer) {
 
   this.scene.add(this.bg);
 
-  if (!window.FILES) {
-    Loader.start(function () {}, function() {});
-  }
-
   this.renderPass = new THREE.RenderPass(this.scene, this.camera);
 }
 

--- a/src/RubixLayer.js
+++ b/src/RubixLayer.js
@@ -81,10 +81,6 @@ function RubixLayer(layer) {
 
   this.camera.position.z = 100;
 
-  if (!window.FILES) {
-    Loader.start(function () {}, function() {});
-  }
-
   this.renderPass = new THREE.RenderPass(this.scene, this.camera);
 }
 

--- a/src/SplooshSobelLayer.js
+++ b/src/SplooshSobelLayer.js
@@ -5,9 +5,6 @@ function SplooshSobelLayer(layer) {
   this.config = layer.config;
   this.shaderPass = new THREE.ShaderPass(SHADERS.splooshsobel);
   this.texture = Loader.loadTexture('res/skybox/ft.jpg');
-  if(!window.FILES) {
-    Loader.start(function() {}, function() {});
-  }
 }
 
 SplooshSobelLayer.prototype.getEffectComposerPass = function() {


### PR DESCRIPTION
Loader.start is a private API of the loader class, and should never be
called from layers. It is also not necessary anymore, as the frontend
takes care of proper reloading automatically.
